### PR TITLE
Fix uninitialized buffer in Cell

### DIFF
--- a/torlib/Cell.cpp
+++ b/torlib/Cell.cpp
@@ -40,7 +40,8 @@ Cell::Cell(u32 circuit_id, cell_command command) {
 	index = POSITION_PAYLOAD_SIZE;
 }
 Cell::Cell() {
-	index = POSITION_PAYLOAD;
+        memset(buffer, 0, sizeof(buffer));
+        index = POSITION_PAYLOAD;
 }
 
 unsigned char Cell::GetCommand() {


### PR DESCRIPTION
## Summary
- clear `Cell` buffer in default constructor

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./tor-connect` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb37c224832daebc3dbda14f5e05